### PR TITLE
List paramPaths with prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ helm plugin update ssm
 ```
 
 ## Usage
-In any **non-default** values file, replace values of secrets with ssm keywords `ssm` and `ssm-path` as shown below.
+In any **non-default** values file, replace values of secrets with ssm keywords `ssm`, `ssm-path`, and `ssm-path-prefix` as shown below.
 #### Single Parameter
 Replace a value-file value with a value from SSM Parameter Store:
 ```
@@ -47,6 +47,34 @@ myConfig: {{ssm-path /prod-config/example}}
  => becomes =>
 
 myConfig: {secret-key-1: "value-1", secret-key-2: "value-2": secret-key-3: "value-3"}
+```
+
+#### Multiple Parameters under Multiple Paths sharing a common prefix
+Let's say I want to include multiple parameter paths that have a common prefix. For example,
+```
+/prod-config/prod_hosts/host_1_key => "secret-value"
+/prod-config/prod_hosts/host_2_key => "secret-value"
+
+/prod-config/api_tokens/app_1_token => "secret-value"
+/prod-config/api_tokens/app_2_token => "secret-value"
+/prod-config/api_tokens/app_3_token => "secret-value"
+
+/prod-config/database_urls/db_url => "secret-value"
+```
+Then the following values file will result in a list of dictionaries of the key/value pairs.
+```
+myConfig: {{ssm-path-prefix /prod-config/}}
+  - prod_hosts
+  - api_tokens
+  - database_urls
+{{end}}
+
+ => becomes =>
+
+myConfig:
+  - {host_1_key: "secret-value", host_2_key: "secret-value"}
+  - {app_1_token: "secret-value", app_2_token: "secret-value", app_3_token: "secret-value"}
+  - {db_url: "secret-value"}
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ This testing setup assumes you have the following parameters in SSM:
 test-secret-value: (value can be anything)
 /test-secret-group/value1: (value can be anything)
 /test-secret-group/value2: (value can be anything)
+/test-secret-group-2/config1/c1key1: (value can be anything)
+/test-secret-group-2/config2/c2key1: (value can be anything)
+/test-secret-group-2/config2/c2key2: (value can be anything)
+
 ...
 (as many as you want under the path /test-secret-group/)
 ```

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "ssm"
-version: "0.1.6"
+version: "0.1.5"
 usage: "AWS SSM parameter injection into Helm value files"
 description: |-
   AWS SSM parameter injection in Helm value files

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "ssm"
-version: "0.1.5"
+version: "0.1.6"
 usage: "AWS SSM parameter injection into Helm value files"
 description: |-
   AWS SSM parameter injection in Helm value files

--- a/tests/testchart/override-values.yaml
+++ b/tests/testchart/override-values.yaml
@@ -6,3 +6,7 @@ image:
 config: {{ssm-path /test-secret-group}}
 secret2: {{ssm test-secret-value}}
 
+nested-configs: {{ssm-path-prefix /test-secret-group-2/}}
+ - config1
+ - config2
+{{end}}

--- a/tests/testchart/override-values.yaml
+++ b/tests/testchart/override-values.yaml
@@ -6,7 +6,8 @@ image:
 config: {{ssm-path /test-secret-group}}
 secret2: {{ssm test-secret-value}}
 
-nested-configs: {{ssm-path-prefix /test-secret-group-2/}}
- - config1
- - config2
+nestedConfigs: {{ssm-path-prefix /test-secret-group-2/}}
+- config1
+- config2
 {{end}}
+keepThisOne: okay

--- a/tests/testchart/templates/deployment.yaml
+++ b/tests/testchart/templates/deployment.yaml
@@ -8,6 +8,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "testchart.name" . }}
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "testchart.name" . }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -21,4 +24,10 @@ spec:
             {{- end }}
             - name: SECRET_2
               value: {{ .Values.secret2 | quote }}
+            {{- range $key, $value := .Values.nestedConfigs }}
+            - name: {{ $key | upper }}
+              value: {{ $value | quote }}
+            {{- end }}
+            - name: SECRET_3
+              value: {{ .Values.keepThisOne | quote }}
 

--- a/tests/testchart/templates/deployment.yaml
+++ b/tests/testchart/templates/deployment.yaml
@@ -24,9 +24,11 @@ spec:
             {{- end }}
             - name: SECRET_2
               value: {{ .Values.secret2 | quote }}
-            {{- range $key, $value := .Values.nestedConfigs }}
+            {{- range .Values.nestedConfigs }}
+            {{- range $key, $value := . }}
             - name: {{ $key | upper }}
               value: {{ $value | quote }}
+            {{- end }}
             {{- end }}
             - name: SECRET_3
               value: {{ .Values.keepThisOne | quote }}


### PR DESCRIPTION
Allows users to list out parameter paths in a more readable way, and include a common prefix.
See the addition to the readme for the new format.

Also now ignores commented-out lines so that the plugin doesn't do unnecessary work on lines that won't be rendered anyway.