### PR TITLE
Use scanner instead of readstring with newline delim

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 go get -d ./...
+go test .
 env GOOS=linux GOARCH=amd64 go build -o helm-ssm-Linux-x86_64 main.go
 env GOOS=darwin GOARCH=amd64 go build -o helm-ssm-Darwin-x86_64 main.go

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -22,7 +21,7 @@ const (
 	SSM_PATH_PREFIX_FORMAT = `{{ssm-path-prefix\s+(\S+)\s?}}`
 	LIST_ITEM_FORMAT = `^\s{0,}-\s(\S+)\n?$`
 	END_FORMAT = `^\s{0,}{{\s?end\s?}}`
-	COMMENT_FORMAT=`^\s{0,}#.*`
+	COMMENT_FORMAT = `^\s{0,}#.*`
 )
 
 type controller struct {
@@ -156,21 +155,20 @@ func readLines(valueFile string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	reader := bufio.NewReader(file)
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err == io.EOF {
-				break
-			} else {
-				return nil, err
-			}
-		}
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		newLine := scanner.Text()
 		// if the line is empty or commented out, don't add
-		if ((line != "\n") && !regexp.MustCompile(COMMENT_FORMAT).Match([]byte(line))) {
-			lines = append(lines, line)
+		if ((newLine != "\n") && !regexp.MustCompile(COMMENT_FORMAT).Match([]byte(newLine))) {
+			lines = append(lines, newLine)
 		}
 	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
 	return lines, nil
 }
 
@@ -376,8 +374,8 @@ func helmCommand(args []string) error {
 		fmt.Println("helm ssm usage:")
 		fmt.Println("\thelm ssm [command] [--keep-temp-values-file] [helm args...]")
 		fmt.Println("Flags:")
-		fmt.Println("\t--keep-temp-values-file\t\t\tIf true, don't clean up the temporary values file populated with ssm values from the current directory\n\n")
-		fmt.Println("Helm Usage:")
+		fmt.Println("\t--keep-temp-values-file\t\t\tIf true, don't clean up the temporary values file populated with ssm values from the current directory")
+		fmt.Println("\n\nHelm Usage:")
 	}
 	helmCmd := exec.Command("helm", args...)
 	out, err := helmCmd.CombinedOutput()

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "ssm"
-version: "0.1.7"
+version: "0.1.8"
 usage: "AWS SSM parameter injection into Helm value files"
 description: |-
   AWS SSM parameter injection in Helm value files


### PR DESCRIPTION
Yanky team found a problem this morning when running a helm upgrade and it complained about a missing value in the values file that was not actually missing. Found through debugging with https://github.com/callrail/helm-ssm/pull/12 that it was not reading in the final line of the values file. It was reading bytes until it hit a `\n` delimeter, so if that newline wasn't there at the end, it just threw away that final string.

Solution: switch to using a scanner that will return the full text input on the line even if it doesn't end in a newline. It keeps reading until the input stops and then returns the whole thing.