### PR TITLE
Use scanner instead of readstring with newline delim

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 go get -d ./...
+go test .
 env GOOS=linux GOARCH=amd64 go build -o helm-ssm-Linux-x86_64 main.go
 env GOOS=darwin GOARCH=amd64 go build -o helm-ssm-Darwin-x86_64 main.go

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "ssm"
-version: "0.1.7"
+version: "0.1.8"
 usage: "AWS SSM parameter injection into Helm value files"
 description: |-
   AWS SSM parameter injection in Helm value files


### PR DESCRIPTION
Yanky team found a problem this morning when running a helm upgrade and it complained about a missing value in the values file that was not actually missing. Found through debugging with https://github.com/callrail/helm-ssm/pull/12 that it was not reading in the final line of the values file. It was reading bytes until it hit a \n delimeter, so if that newline wasn't there at the end, it just threw away that final string.

Solution: switch to using a scanner that will return the full text input on the line even if it doesn't end in a newline. It keeps reading until the input stops and then returns the whole thing.