### PR TITLE
Send helm output to stderr on error

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: '1.13.3'
-      - name: Build go binaries
+      - name: Unit test and build go binaries
         run: ./build.sh
       - name: Bump version and push tag
         id: create_tag

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "ssm"
-version: "0.1.8"
+version: "0.1.9"
 usage: "AWS SSM parameter injection into Helm value files"
 description: |-
   AWS SSM parameter injection in Helm value files


### PR DESCRIPTION
1) send helm ssm's errors to stderr
2) When we pass the command to helm and helm hits an error, it's sending the error message to stdout and "exit status 1" to stderr. Make it print the error message to stderr also.

this fixes the problem where the error message gets swallowed up & invisible to users in the CICD pipelines when we send the dry-run output to a file.