### PR TITLE
Add a Darwin-arm64 build for M1 MacBooks

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.3'
+          go-version: '1.16.3'
       - name: Unit test and build go binaries
         run: ./build.sh
       - name: Bump version and push tag
@@ -41,7 +41,7 @@ jobs:
           asset_path: helm-ssm-Linux-x86_64
           asset_name: helm-ssm_${{ steps.create_tag.outputs.new_tag }}_Linux_x86_64
           asset_content_type: application/octet-stream
-      - name: Upload release asset macOS
+      - name: Upload release asset Intel macOS
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,4 +49,13 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: helm-ssm-Darwin-x86_64
           asset_name: helm-ssm_${{ steps.create_tag.outputs.new_tag }}_Darwin_x86_64
+          asset_content_type: application/octet-stream
+      - name: Upload release asset ARM macOS
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: helm-ssm-Darwin-arm64
+          asset_name: helm-ssm_${{ steps.create_tag.outputs.new_tag }}_Darwin_arm64
           asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+helm-ssm-Darwin-*
+helm-ssm-Linux-*

--- a/build.sh
+++ b/build.sh
@@ -4,3 +4,4 @@ go get -d ./...
 go test .
 env GOOS=linux GOARCH=amd64 go build -o helm-ssm-Linux-x86_64 main.go
 env GOOS=darwin GOARCH=amd64 go build -o helm-ssm-Darwin-x86_64 main.go
+env GOOS=darwin GOARCH=arm64 go build -o helm-ssm-Darwin-arm64 main.go


### PR DESCRIPTION
## Problem

Currently, when you run the command `helm plugin install https://github.com/callrail/helm-ssm` on an M1 MacBook, the `helm-ssm` binary installed is a text file containing the string `Not found`. This is because the install script is getting a 404 error trying to fetch a binary for an architecture we're not building.

## Solution

Go 1.16 adds support for the Apple M1 chip. Let's use it!

## What this does

- Adds a `darwin-arm64` target to the build script.
- Bumps the Go version used in the github workflow to 1.16.
- Add a `Darwin-arm64` release asset to the github workflow.