### PR TITLE
fix: plugin version in yaml file

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "ssm"
-version: "0.1.11"
+version: "0.2.1"
 usage: "AWS SSM parameter injection into Helm value files"
 description: |-
   AWS SSM parameter injection in Helm value files


### PR DESCRIPTION
[JIRA](https://callrail.atlassian.net/browse/PLATFORM-3483)

Oops, helm-ssm is now on `v0.2.0` (from DP's and my change [here](https://github.com/callrail/helm-ssm/pull/19)), but when I update it locally, it’s still saying `v0.1.11`. I tracked that down to the plugin.yaml repo- I needed to bump the version there too. ~Fix that now, but use `[skip ci]` so as to not release another new patch version.~
Now I'm releasing v0.2.1 which will have the right version in the plugin meta bundled in there